### PR TITLE
Fixed type loosing code in GelfConverter.

### DIFF
--- a/Target/GelfConverter.cs
+++ b/Target/GelfConverter.cs
@@ -72,7 +72,11 @@ namespace Gelf4NLog.Target
         private static void AddAdditionalField(IDictionary<string, JToken> jObject, KeyValuePair<object, object> property)
         {
             var key = property.Key as string;
-            var value = property.Value as string;
+            JToken value = null;
+            if (property.Value != null && property.Value.GetType().IsArray)
+                value = new JArray(property.Value);
+            else
+                value = new JValue(property.Value);
 
             if (key == null) return;
 

--- a/UnitTest/GelfConverterTest.cs
+++ b/UnitTest/GelfConverterTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using Gelf4NLog.Target;
 using NLog;
@@ -24,6 +25,8 @@ namespace Gelf4NLog.UnitTest
                                    };
                 logEvent.Properties.Add("customproperty1", "customvalue1");
                 logEvent.Properties.Add("customproperty2", "customvalue2");
+                logEvent.Properties.Add("custompropertyint", 199);
+                logEvent.Properties.Add("custompropertyarray", new [] {1,2,3});
 
                 var jsonObject = new GelfConverter().GetGelfJson(logEvent, "TestFacility");
 
@@ -40,10 +43,12 @@ namespace Gelf4NLog.UnitTest
                 
                 Assert.AreEqual("customvalue1", jsonObject.Value<string>("_customproperty1"));
                 Assert.AreEqual("customvalue2", jsonObject.Value<string>("_customproperty2"));
+                Assert.AreEqual(199, jsonObject.Value<int>("_custompropertyint"));
+                Assert.AreEqual(new [] {1,2,3}, jsonObject["_custompropertyarray"].ToObject<int[]>());
                 Assert.AreEqual("GelfConverterTestLogger", jsonObject.Value<string>("_LoggerName"));
                 
                 //make sure that there are no other junk in there
-                Assert.AreEqual(12, jsonObject.Count);
+                Assert.AreEqual(14, jsonObject.Count);
             }
 
             [Test]


### PR DESCRIPTION
Previous version changed any type that was not string to null. However, all gelf, log stash, elastic search and kibana handle more data types then strings (like numbers and arrays).

This commit fixes it allowing for a datatype to be pushed to gelf. Modified unit tests and verified that all works fine end to end in our QA environment.

Hope it helps community,
m.
